### PR TITLE
Task(538918): Included support for Upgrade Center service on Bold Reports upgrades

### DIFF
--- a/helm/boldreports/templates/deployment.yaml
+++ b/helm/boldreports/templates/deployment.yaml
@@ -169,6 +169,8 @@ spec:
         {{- if eq $service.app "id-ums" }}
         - name: BOLD_SERVICES_USE_SITE_IDENTIFIER
           value: "true"
+        - name: BOLD_SERVICES_UPGRADECENTER_ENABLE
+          value: "{{ $.Values.upgradeCenter.enabled | default "false" }}"
         envFrom:
         - secretRef:
               name: bold-user-secret

--- a/helm/boldreports/templates/traefik.yaml
+++ b/helm/boldreports/templates/traefik.yaml
@@ -47,6 +47,19 @@ spec:
     regex: ^/etlservice(/|$)(.*)
     replacement: /$2
 ---
+{{- if .Values.upgradeCenter.enabled }}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: boldreports-upgrade-center-trailing-slash
+  {{- include "boldreports.namespace" . | nindent 2 }}
+spec:
+  redirectRegex:
+    regex: ^(https?://[^/]+{{ .Values.upgradeCenter.ingressPath }})$
+    replacement: ${1}/
+    permanent: true
+{{- end }}
+---
 {{- if (and (hasKey .Values.loadBalancer "multipleHost") (hasKey .Values.loadBalancer.multipleHost "hostArray") (gt (len .Values.loadBalancer.multipleHost.hostArray) 0)) }}
   {{- range $groupIdx, $group := .Values.loadBalancer.multipleHost.hostArray }}
     {{- range $hostIdx, $host := $group.hosts }}
@@ -274,6 +287,29 @@ spec:
               name: bold.k8s.pod.id
               maxAge: {{ default "600" $.Values.loadBalancer.affinityCookie.affinityCookieExpiration }}
           {{- end }}
+    {{- if .Values.upgradeCenter.enabled }}
+    - match: |
+        {{- if $isIP }}
+        PathPrefix(`{{ $subPath }}/upgrade-center`)
+        {{- else }}
+        Host(`{{ $host }}`) && PathPrefix(`{{ $subPath }}/upgrade-center`)
+        {{- end }}
+      kind: Rule
+      middlewares:
+        - name: body-limit-200m
+        - name: boldreports-upgrade-center-trailing-slash
+      priority: 1000
+      services:
+        - name: boldreports-upgrade-center
+          port: 80
+          serversTransport: long-timeouts-transport
+          {{- if $.Values.loadBalancer.affinityCookie.enable }}
+          sticky:
+            cookie:
+              name: bold.k8s.pod.id
+              maxAge: {{ default "600" $.Values.loadBalancer.affinityCookie.affinityCookieExpiration }}
+          {{- end }}
+    {{- end }}
 ---
     {{- end }}  {{- /* end per-host */ -}}
   {{- end }}  {{- /* end per-group */ -}}
@@ -501,5 +537,28 @@ spec:
               name: bold.k8s.pod.id
               maxAge: {{ default "600" .Values.loadBalancer.affinityCookie.affinityCookieExpiration }}
           {{- end }}
+    {{- if .Values.upgradeCenter.enabled }}
+    - match: |
+        {{- if $isIP }}
+        PathPrefix(`{{ $subPath }}/upgrade-center`)
+        {{- else }}
+        Host(`{{ $baseHost }}`) && PathPrefix(`{{ $subPath }}/upgrade-center`)
+        {{- end }}
+      kind: Rule
+      middlewares:
+        - name: body-limit-200m
+        - name: boldreports-upgrade-center-trailing-slash
+      priority: 1000
+      services:
+        - name: boldreports-upgrade-center
+          port: 80
+          serversTransport: long-timeouts-transport
+          {{- if $.Values.loadBalancer.affinityCookie.enable }}
+          sticky:
+            cookie:
+              name: bold.k8s.pod.id
+              maxAge: {{ default "600" $.Values.loadBalancer.affinityCookie.affinityCookieExpiration }}
+          {{- end }}
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/boldreports/templates/upgrade-center-deployment.yaml
+++ b/helm/boldreports/templates/upgrade-center-deployment.yaml
@@ -1,0 +1,369 @@
+{{- if .Values.upgradeCenter.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: boldreports-upgrade-center
+{{ include "boldreports.namespace" . | indent 2 }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}_{{ .Chart.Version }}
+    app.kubernetes.io/name: boldreports-upgrade-center
+    app.kubernetes.io/instance: {{ .Release.Name }}
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: boldreports-upgrade-center
+{{ include "boldreports.namespace" . | indent 2 }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}_{{ .Chart.Version }}
+    app.kubernetes.io/name: boldreports-upgrade-center
+    app.kubernetes.io/instance: {{ .Release.Name }}
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - create
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: boldreports-upgrade-center  
+{{ include "boldreports.namespace" . | indent 2 }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}_{{ .Chart.Version }}
+    app.kubernetes.io/name: boldreports-upgrade-center
+    app.kubernetes.io/instance: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: boldreports-upgrade-center
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: boldreports-upgrade-center
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: boldreports-upgrade-center-config
+{{ include "boldreports.namespace" . | indent 2 }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}_{{ .Chart.Version }}
+    app.kubernetes.io/name: boldreports-upgrade-center
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    {{- end }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  releaseVersionsApiUrl: "https://boldbi-release-api.boldbidemo.com/reports/version/json"
+  idpApi: "http://id-api-service:6001/api"
+  ums: "http://id-ums-service:6002/ums"
+  playwrightRunnerImage: "sivakumar2809/boldreports-upgrade-center-qa:v2.1"
+  playwrightJobTimeoutSeconds: "9000"
+  playwrightCompletedJobTtlSeconds: "3600"
+  playwrightWorkers: "4"
+  playwrightJobCpuRequest: "2"
+  playwrightJobCpuLimit: "4"
+  playwrightJobMemoryRequest: "4Gi"
+  playwrightJobMemoryLimit: "6Gi"
+  playwrightSharedStateVolumeEnabled: "true"
+  playwrightSharedStateStorageClassName: ""
+  playwrightSharedStateStorageSize: "1Gi"
+  playwrightSharedStateAccessMode: "ReadWriteOnce"
+  playwrightSharedStateMountPath: "/app/playwright-shared-state"
+  playwrightSharedStateFsGroup: "1001"
+  playwrightPodHoldSeconds: "180"
+  playwrightPassRateThreshold: "40"
+  playwrightReportUploadBaseUrl: "http://boldreports-upgrade-center/upgrade-center/api/playwright-reports"
+  playwrightResultUploadBaseUrl: "http://boldreports-upgrade-center/upgrade-center/api/playwright-results"
+  productHealthCheckEnabled: "true"
+  productHealthCheckTimeoutSeconds: "300"
+  productHealthCheckPollSeconds: "10"
+  productHealthCheckRequestTimeoutSeconds: "10"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: boldreports-upgrade-center
+{{ include "boldreports.namespace" . | indent 2 }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}_{{ .Chart.Version }}
+    app.kubernetes.io/name: boldreports-upgrade-center
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    {{- end }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.upgradeCenter.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: boldreports-upgrade-center
+      # app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: boldreports-upgrade-center
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      serviceAccountName: boldreports-upgrade-center
+      automountServiceAccountToken: true
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      - name: {{ .Values.imagePullSecrets }}
+      {{- end }}
+      containers:
+        - name: boldreports-upgrade-center
+          image: "{{ .Values.upgradeCenter.image.repo }}:{{ .Values.upgradeCenter.image.tag }}"
+          imagePullPolicy: {{ .Values.upgradeCenter.image.pullPolicy }}
+          ports:
+            - containerPort: 8080
+              name: http
+          envFrom:
+            - secretRef:
+                name: boldreports-upgrade-center-playwright
+                optional: true
+          env:
+            - name: ASPNETCORE_ENVIRONMENT
+              value: "Production"
+            - name: ASPNETCORE_URLS
+              value: "http://+:8080"
+            - name: ASPNETCORE_FORWARDEDHEADERS_ENABLED
+              value: "true"
+            - name: UpgradeCenter__ReleaseVersionsApiUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: releaseVersionsApiUrl
+            - name: UpgradeCenter__ProductName
+              value: "Bold Reports"
+            - name: UpgradeCenter__Services__IdpApi
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: idpApi
+            - name: UpgradeCenter__Services__Ums
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: ums
+            - name: UpgradeCenter__Playwright__UseKubernetesJob
+              value: "true"
+            - name: UpgradeCenter__Playwright__RunnerImage
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: playwrightRunnerImage
+            - name: UpgradeCenter__Playwright__JobTimeoutSeconds
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: playwrightJobTimeoutSeconds
+            - name: UpgradeCenter__Playwright__CompletedJobTtlSeconds
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: playwrightCompletedJobTtlSeconds
+            - name: UpgradeCenter__Playwright__WorkerCount
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: playwrightWorkers
+            - name: UpgradeCenter__Playwright__JobCpuRequest
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: playwrightJobCpuRequest
+            - name: UpgradeCenter__Playwright__JobCpuLimit
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: playwrightJobCpuLimit
+            - name: UpgradeCenter__Playwright__JobMemoryRequest
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: playwrightJobMemoryRequest
+            - name: UpgradeCenter__Playwright__JobMemoryLimit
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: playwrightJobMemoryLimit
+            - name: UpgradeCenter__Playwright__SharedStateVolumeEnabled
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: playwrightSharedStateVolumeEnabled
+            - name: UpgradeCenter__Playwright__SharedStateStorageClassName
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: playwrightSharedStateStorageClassName
+            - name: UpgradeCenter__Playwright__SharedStateStorageSize
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: playwrightSharedStateStorageSize
+            - name: UpgradeCenter__Playwright__SharedStateAccessMode
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: playwrightSharedStateAccessMode
+            - name: UpgradeCenter__Playwright__SharedStateMountPath
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: playwrightSharedStateMountPath
+            - name: UpgradeCenter__Playwright__SharedStateFsGroup
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: playwrightSharedStateFsGroup
+            - name: PLAYWRIGHT_POD_HOLD_SECONDS
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: playwrightPodHoldSeconds
+            - name: UpgradeCenter__Playwright__PassRateThreshold
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: playwrightPassRateThreshold
+            - name: UpgradeCenter__Playwright__ReportUploadBaseUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: playwrightReportUploadBaseUrl
+            - name: UpgradeCenter__Playwright__ResultUploadBaseUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: playwrightResultUploadBaseUrl
+            - name: UpgradeCenter__ProductHealthCheck__Enabled
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: productHealthCheckEnabled
+            - name: UpgradeCenter__ProductHealthCheck__TimeoutSeconds
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: productHealthCheckTimeoutSeconds
+            - name: UpgradeCenter__ProductHealthCheck__PollSeconds
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: productHealthCheckPollSeconds
+            - name: UpgradeCenter__ProductHealthCheck__RequestTimeoutSeconds
+              valueFrom:
+                configMapKeyRef:
+                  name: boldreports-upgrade-center-config
+                  key: productHealthCheckRequestTimeoutSeconds
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            runAsGroup: 0
+          readinessProbe:
+            httpGet:
+              path: /upgrade-center/health-check
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /upgrade-center/health-check
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1536Mi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - mountPath: /app/App_Data
+              name: upgrade-center-volume
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: upgrade-center-volume
+          persistentVolumeClaim:
+            claimName: bold-fileserver-claim
+      {{- if .Values.tolerationEnable }}
+      tolerations:
+      {{- range .Values.tolerations }}
+        - key: {{ .key }}
+          operator: {{ .operator }}
+          value: {{ .value }}
+          effect: {{ .effect }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.nodeAffinityEnable }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: {{ .Values.nodeAffinity.key }}
+                    operator: {{ .Values.nodeAffinity.operator }}
+                    values:
+                      - {{ .Values.nodeAffinity.value }}
+      {{- end }}
+{{- end }}

--- a/helm/boldreports/templates/upgrade-center-secret.yaml
+++ b/helm/boldreports/templates/upgrade-center-secret.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.upgradeCenter.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: boldreports-upgrade-center-playwright
+  {{- include "boldreports.namespace" . | nindent 2 }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}_{{ .Chart.Version }}
+    app.kubernetes.io/name: boldreports-upgrade-center-playwright
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    {{- end }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+stringData:
+  BOLDREPORTS_ADMIN_USERNAME: {{ if .Values.rootUserDetails.email }}{{ .Values.rootUserDetails.email | quote }}{{ else }}{{ .Values.upgradeCenter.secret.BOLDREPORTS_ADMIN_USERNAME | quote }}{{ end }}
+  BOLDREPORTS_ADMIN_EMAIL: {{ if .Values.rootUserDetails.email }}{{ .Values.rootUserDetails.email | quote }}{{ else }}{{ .Values.upgradeCenter.secret.BOLDREPORTS_ADMIN_EMAIL | quote }}{{ end }}
+  BOLDREPORTS_ADMIN_PASSWORD: {{ if .Values.rootUserDetails.password }}{{ .Values.rootUserDetails.password | quote }}{{ else }}{{ .Values.upgradeCenter.secret.BOLDREPORTS_ADMIN_PASSWORD | quote }}{{ end }}
+{{- end }}

--- a/helm/boldreports/templates/upgrade-center-service.yaml
+++ b/helm/boldreports/templates/upgrade-center-service.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.upgradeCenter.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: boldreports-upgrade-center
+  {{- include "boldreports.namespace" . | nindent 2 }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}_{{ .Chart.Version }}
+    app.kubernetes.io/name: boldreports-upgrade-center
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    {{- end }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: boldreports-upgrade-center
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+{{- end }}


### PR DESCRIPTION
The Bold Reports Upgrade Center is a UI-driven, in-cluster workflow for orchestrating, validating, and smoke-testing Bold Reports upgrades using Playwright. This change introduces the Upgrade Center as an opt-in component of the boldReports Helm chart, with multi-ingress support (Traefik, NGINX, Kong) and feature-flag propagation into the identity stack.

Changes:

- Added upgrade-center-deployment.yaml (Deployment, ServiceAccount, Role, RoleBinding, ConfigMap).
- Added upgrade-center-service.yaml (ClusterIP Service, port 80).
- Added upgrade-center-secret.yaml (Playwright admin credentials, with rootUserDetails fallback).
- Added upgrade-center-ingress.yaml (Traefik IngressRoute + middleware; NGINX and Kong Ingress).
- Added upgradeCenter configuration in values.yaml (image, replicas, resources, ingressPath, secret, enable flag).
- Added BOLD_SERVICES_UPGRADECENTER_ENABLE env var to the id-ums container in deployment.yaml.

This change enables the Bold Reports Upgrade Center to be deployed and managed within the Kubernetes cluster through the Bold Reports Helm chart.